### PR TITLE
Fix absolute path specifiers on Windows

### DIFF
--- a/src/babel-register-esm.js
+++ b/src/babel-register-esm.js
@@ -1,5 +1,5 @@
 import path from 'path'
-import {fileURLToPath} from 'url'
+import {fileURLToPath, pathToFileURL} from 'url'
 import babel from '@babel/core'
 
 const SUPPORTED_EXTENSIONS = ['.js', '.jsx', '.ts', '.tsx']
@@ -15,6 +15,7 @@ const SUPPORTED_EXTENSIONS = ['.js', '.jsx', '.ts', '.tsx']
  */
 export async function resolve(specifier, context, nextResolve) {
   try {
+    if(path.isAbsolute(specifier)) specifier = pathToFileURL(specifier).toString();
     const x = await nextResolve(specifier, context)
     return x
   } catch (/**@type {any} */ error) {

--- a/src/babel-register-esm.js
+++ b/src/babel-register-esm.js
@@ -19,7 +19,7 @@ export async function resolve(specifier, context, nextResolve) {
     const x = await nextResolve(specifier, context)
     return x
   } catch (/**@type {any} */ error) {
-    if (!specifier.startsWith('.') && !specifier.startsWith('/')) throw error
+    if (!specifier.startsWith('.') && !specifier.startsWith('file:')) throw error
 
     const extension = path.extname(
       fileURLToPath(/**@type {import('url').URL}*/ (new URL(specifier, context.parentURL))),

--- a/src/babel-register-esm.js
+++ b/src/babel-register-esm.js
@@ -15,7 +15,7 @@ const SUPPORTED_EXTENSIONS = ['.js', '.jsx', '.ts', '.tsx']
  */
 export async function resolve(specifier, context, nextResolve) {
   try {
-    if(path.isAbsolute(specifier)) specifier = pathToFileURL(specifier).toString();
+    if (path.isAbsolute(specifier)) specifier = pathToFileURL(specifier).toString()
     const x = await nextResolve(specifier, context)
     return x
   } catch (/**@type {any} */ error) {


### PR DESCRIPTION
Previously, if the provided `specifier` was a Windows absolute local path (one that contains a drive letter, i.e. `D:\Project\src\util.ts`), Node would incorrectly parse the drive letter `D:` as the URL scheme, which then causes `ERR_UNSUPPORTED_ESM_URL_SCHEME`. This can be demonstrated by, for example, running `yarn test` for apache/incubator-annotator, which uses `babel-register-esm` to load TS tests. This PR checks if the provided `specifier` is an absolute path already, and if so, converts that to a `file://` URL early on.

I have tested this change on both Windows and a Ubuntu machine running Mocha tests for apache/incubator-annotator, and it did not appear to bring any unintended consequences.